### PR TITLE
Fix a bug with verisoft files contain unicode

### DIFF
--- a/IQDMPDF/file_processor.py
+++ b/IQDMPDF/file_processor.py
@@ -155,7 +155,7 @@ def process_file(file_path, output_file, output_dir=None):
             ):  # if file doesn't exist, need to write columns
                 with open(current_file, "w") as csv:
                     csv.write(",".join(parser.columns) + "\n")
-            with open(current_file, "a") as csv:  # write the processed data
+            with open(current_file, "a", encoding='utf-8') as csv:  # write the processed data
                 csv.write(row + "\n")
     else:
         print("Skipping: %s" % file_path)

--- a/IQDMPDF/file_processor.py
+++ b/IQDMPDF/file_processor.py
@@ -155,7 +155,9 @@ def process_file(file_path, output_file, output_dir=None):
             ):  # if file doesn't exist, need to write columns
                 with open(current_file, "w") as csv:
                     csv.write(",".join(parser.columns) + "\n")
-            with open(current_file, "a", encoding='utf-8') as csv:  # write the processed data
+            with open(
+                current_file, "a", encoding="utf-8"
+            ) as csv:  # write the processed data
                 csv.write(row + "\n")
     else:
         print("Skipping: %s" % file_path)


### PR DESCRIPTION
Fix a bug when unicode is present in the resulting CSV. This fix writes the CSV with UTF-8 encoding.
```
Processing (1 of 3): .\ANON0001.pdf 
Traceback (most recent call last): 
  File "C:\Projects\venvs\iqdmpdf\Scripts\IQDMPDF-script.py", line 33, in <module> 
    sys.exit(load_entry_point('IQDMPDF', 'console_scripts', 'IQDMPDF')()) 
  File "c:\projects\iqdm-pdf\IQDMPDF\main.py", line 23, in main 
    process_files(**validated_kwargs) 
  File "c:\projects\iqdm-pdf\IQDMPDF\file_processor.py", line 69, in process_files 
    raise e 
  File "c:\projects\iqdm-pdf\IQDMPDF\file_processor.py", line 66, in process_files 
    process_file(file, output_file, output_dir) 
  File "c:\projects\iqdm-pdf\IQDMPDF\file_processor.py", line 160, in process_file 
    csv.write(row + "\n") 
  File "C:\Python39\lib\encodings\cp1252.py", line 19, in encode 
    return codecs.charmap_encode(input,self.errors,encoding_table)[0] 
UnicodeEncodeError: 'charmap' codec can't encode character '\u2264' in position 565: character maps to <undefined> 
```